### PR TITLE
data: use metainfo instead appdata

### DIFF
--- a/data/com.github.bleakgrey.tootle.metainfo.xml.in
+++ b/data/com.github.bleakgrey.tootle.metainfo.xml.in
@@ -24,6 +24,7 @@
   <url type="homepage">https://github.com/bleakgrey</url>
   <url type="bugtracker">https://github.com/bleakgrey/tootle/issues</url>
   <url type="donation">https://liberapay.com/bleakgrey/donate</url>
+  <update_contact>bleakgrey@gmail.com</update_contact>
 
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">none</content_attribute>

--- a/data/meson.build
+++ b/data/meson.build
@@ -28,8 +28,8 @@ i18n.merge_file(
 )
 
 i18n.merge_file(
-    input: meson.project_name() + '.appdata.xml.in',
-    output: meson.project_name() + '.appdata.xml',
+    input: meson.project_name() + '.metainfo.xml.in',
+    output: meson.project_name() + '.metainfo.xml',
     po_dir: join_paths(meson.source_root(), 'po'),
     install: true,
     install_dir: join_paths(get_option('datadir'), 'metainfo')


### PR DESCRIPTION
Component metadata of type desktop-application as described in Section 2.2, “Desktop Applications” can be installed with an .appdata.xml extension as well for historical reasons.

https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html

Signed-off-by: David Heidelberg <david@ixit.cz>